### PR TITLE
Check active window in Linux

### DIFF
--- a/_done.fish
+++ b/_done.fish
@@ -1,5 +1,6 @@
 function _done --on-event fish_prompt
 	set -l platform
+	set -l terminals "tmux|iTerm"
 
 	if command -s tell > /dev/null
 		set platform osx
@@ -24,17 +25,20 @@ function _done --on-event fish_prompt
 
 			switch $platform
 				case osx
-					# Only show the notification if iTerm is not focused
+					# Only show the notification if terminal is not focused
 					echo "
 						tell application \"System Events\"
 							set activeApp to name of first application process whose frontmost is true
-							if \"iTerm\" is not in activeApp then
+							if \"$terminals\" is not in activeApp then
 								display notification \"Finished in $duration\" with title \"$history[1]\"
 							end if
 						end tell
 						" | osascript
 				case linux
-					notify-send "Finished in $duration with title $history[1]"
+					set active_window (xprop -id (xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) _NET_WM_NAME)
+					if echo $active_window | grep -vqE $terminals
+						notify-send "Finished in $duration with title $history[1]"
+					end
 			end
 		end
 	end

--- a/_done.fish
+++ b/_done.fish
@@ -1,6 +1,6 @@
 function _done --on-event fish_prompt
 	set -l platform
-	set -l terminals "tmux|iTerm"
+	set -l terminals "termite|gnome-terminal|iTerm"
 
 	if command -s tell > /dev/null
 		set platform osx
@@ -35,7 +35,7 @@ function _done --on-event fish_prompt
 						end tell
 						" | osascript
 				case linux
-					set active_window (xprop -id (xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) _NET_WM_NAME)
+					set active_application (xprop -id (xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) WM_CLASS)
 					if echo $active_window | grep -vqE $terminals
 						notify-send "Finished in $duration with title $history[1]"
 					end


### PR DESCRIPTION
* Uses xprop to check that the active window is not a terminal
* Uses an array of terminals (currently tmux, iTerm)

Depends on: #7. Closes: #8.