### PR TITLE
Make the time display more easily parsable by humans

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -41,7 +41,7 @@ end
 function __done_ended --on-event fish_prompt
 	if test $CMD_DURATION
 		# Store duration of last command
-		set duration (echo "$CMD_DURATION 1000" | awk '{printf "%.3f", $1 / $2}')
+		set duration (echo "$CMD_DURATION" | humanize_duration)
 		set notify_duration 10000
 
 		if begin
@@ -49,7 +49,6 @@ function __done_ended --on-event fish_prompt
 				and test $__done_initial_window_id != (__done_get_window_id)  # terminal or window not in foreground
 			end
 
-			set duration (date -d "1970-01-01 $duration seconds" +%H:%M:%S)
 			set -l title "Finished in $duration."
 			set -l message "$history[1]"
 

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -49,7 +49,7 @@ function __done_ended --on-event fish_prompt
 				and test $__done_initial_window_id != (__done_get_window_id)  # terminal or window not in foreground
 			end
 
-			set -l title "Finished in $duration."
+			set -l title "Finished in $duration"
 			set -l message "$history[1]"
 
 			if type -q terminal-notifier  # https://github.com/julienXX/terminal-notifier

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -41,7 +41,7 @@ end
 function __done_ended --on-event fish_prompt
 	if test $CMD_DURATION
 		# Store duration of last command
-		set duration (echo "$CMD_DURATION 1000" | awk '{printf "%.3fs", $1 / $2}')
+		set duration (echo "$CMD_DURATION 1000" | awk '{printf "%.3f", $1 / $2}')
 		set notify_duration 10000
 
 		if begin
@@ -49,7 +49,8 @@ function __done_ended --on-event fish_prompt
 				and test $__done_initial_window_id != (__done_get_window_id)  # terminal or window not in foreground
 			end
 
-			set -l title "Finished in $duration"
+			set duration (date -d "1970-01-01 $duration seconds" +%H:%M:%S)
+			set -l title "Finished in $duration."
 			set -l message "$history[1]"
 
 			if type -q terminal-notifier  # https://github.com/julienXX/terminal-notifier

--- a/fishfile
+++ b/fishfile
@@ -1,0 +1,1 @@
+humanize_duration


### PR DESCRIPTION
Since the notification is only shown after 10 seconds, I think the milliseconds display is not very useful. Instead, since this will only be shown for long-running commands, I have changed the format to look like `01:54:22`.

This fixes #15.