### PR TITLE
Fix tmux integration support

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -34,7 +34,7 @@ end
 function __done_is_tmux_window_active
 	set -q fish_pid; or set -l fish_pid %self
 
-	tmux list-panes -a -F "#{session_attached} #{window_active} #{pane_pid}" | string match -q "1 1 $fish_pid"
+	not tmux list-panes -a -F "#{session_attached} #{window_active} #{pane_pid}" 2> /dev/null | string match -q "1 0 $fish_pid"
 end
 
 function __done_is_process_window_focused
@@ -54,14 +54,14 @@ end
 
 # verify that the system has graphical capabilites before initializing
 if test -z "$SSH_CLIENT"  # not over ssh
-and test -n __done_get_window_id  # is able to get window id
+and test -n __done_get_focused_window_id  # is able to get window id
 
 	set -g __done_initial_window_id ''
 	set -q __done_min_cmd_duration; or set -g __done_min_cmd_duration 5000
 	set -q __done_exclude; or set -g __done_exclude 'git (?!push|pull)'
 
 	function __done_started --on-event fish_preexec
-		set __done_initial_window_id (__done_get_window_id)
+		set __done_initial_window_id (__done_get_focused_window_id)
 	end
 
 	function __done_ended --on-event fish_prompt


### PR DESCRIPTION
Fix wrong method calls introduced in #9298e65dfee
We want to check that our PID is in an attached tmux the window is NOT
active, otherwise we have false postive when we have terminal with and withouth
tmux running.
Suppress tmux warning when no tmux server is running

Fixes: #32 #34

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>